### PR TITLE
added GATT op timing and message sending for 4 gatt comm types

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <uses-feature
         android:name="android.hardware.bluetooth_le"

--- a/app/src/main/java/com/adafruit/bleuart/ArgumentSplash.java
+++ b/app/src/main/java/com/adafruit/bleuart/ArgumentSplash.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Array;
 import java.util.*;
 import java.lang.reflect.Field;
 
-public class ArgumentSplash extends Activity {
+public class ArgumentSplash extends Activity implements BluetoothRestarter.RestartListener {
 
     final static int CENTRAL = 0;
     final static int PERIPHERAL = 1;
@@ -31,12 +31,35 @@ public class ArgumentSplash extends Activity {
 
     final static int CONNECTABLE = 1;
 
+    BluetoothRestarter btRestarter = null;
+
+    private boolean buttonClicked = false;
+    private boolean btRestarted = false;
+    private Intent i = null;
+
+    public void onRestartComplete()
+    {
+        Log.i("bleuart", "Restarted Bluetooth!");
+        btRestarted = true;
+        if (buttonClicked) {
+            this.go();
+        }
+    }
+
+    void go(){
+        startActivity(i);
+        finish();
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_argument_splash);
 
+        btRestarter = new BluetoothRestarter(this);
+
         checkPermissions();
+
     }
 
     private static boolean hasPermissions(Context context, String... permissions) {
@@ -62,7 +85,7 @@ public class ArgumentSplash extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
-
+        btRestarter.restart(this);
     }
 
     @Override
@@ -163,10 +186,12 @@ public class ArgumentSplash extends Activity {
         sendBundle.putInt("gattComm", gattComm);
 
 
-        Intent i = new Intent(ArgumentSplash.this, MainActivity.class);
+        i = new Intent(ArgumentSplash.this, MainActivity.class);
         i.putExtras(sendBundle);
-        startActivity(i);
+        buttonClicked = true;
 
-        finish();
+        if (btRestarted) {
+            this.go();
+        }
     }
 }

--- a/app/src/main/java/com/adafruit/bleuart/ArgumentSplash.java
+++ b/app/src/main/java/com/adafruit/bleuart/ArgumentSplash.java
@@ -95,7 +95,6 @@ public class ArgumentSplash extends Activity {
         boolean isMtu = cliArgs.switchPresent("--mtu");
         boolean isGattCommType = cliArgs.switchPresent("--gatt-comm");
 
-        double logAdvTimeDouble = 0;
         double advIntervalDouble = 0;
         double scanSettingDouble = 0;
         double connIntervalDouble = 0;
@@ -111,8 +110,7 @@ public class ArgumentSplash extends Activity {
             role = PERIPHERAL;
 
         if (isLogAdvTime) {
-            logAdvTimeDouble = cliArgs.switchDoubleValue("--log-adv-t");
-            logAdvTime = (int) logAdvTimeDouble;
+           logAdvTime = 1;
         }
 
         if (isAdvInterval) {

--- a/app/src/main/java/com/adafruit/bleuart/BluetoothLeUartServer.java
+++ b/app/src/main/java/com/adafruit/bleuart/BluetoothLeUartServer.java
@@ -20,10 +20,14 @@ import android.bluetooth.le.BluetoothLeAdvertiser;
 import android.content.Context;
 import android.os.ParcelUuid;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.util.HashSet;
+import java.util.Random;
 import java.util.Set;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,6 +43,8 @@ import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.Message;
 import android.support.annotation.MainThread;
+
+import android.os.SystemClock;
 
 import android.os.Build;
 import android.util.Log;
@@ -105,6 +111,35 @@ class BluetoothLeUartServer extends BluetoothGattServerCallback implements UartB
 
     private int advertisingInterval;
     private int gattComm;
+
+    private File mGattOutFile = null;
+
+    private Thread bgThread = null;
+
+    private class SaveToFileRunnable implements Runnable {
+
+        private File file = null;
+        private byte [] buffer;
+        private boolean append;
+        public SaveToFileRunnable (File outFile, byte [] data, boolean append) {
+            this.file = outFile;
+            this.buffer = data.clone();
+            this.append = append;
+        }
+
+        public void run(){
+            FileOutputStream stream = null;
+            if (null != file) {
+                try {
+                    stream = new FileOutputStream(file, append);
+                    stream.write(buffer);
+                    stream.close();
+                } catch(IOException e) {
+                }
+            }
+        }
+    }
+
 
     public class WriteData {
         public BluetoothDevice device;
@@ -180,7 +215,7 @@ class BluetoothLeUartServer extends BluetoothGattServerCallback implements UartB
 
     public void stop(){
 
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
+        if (false/*Build.VERSION.SDK_INT > Build.VERSION_CODES.N*/) {
            // mBluetoothLeAdvertiser.stopAdvertisingSet(mAdvSetCallback);
         } else {
             mBluetoothLeAdvertiser.stopAdvertising(mAdvertiseCallback);
@@ -212,7 +247,42 @@ class BluetoothLeUartServer extends BluetoothGattServerCallback implements UartB
         return mMtu;
     }
 
+    private long gattLastTS = 0;
+    private String [] gattBatch = new String [1000];
+    private int gattBatchIndex = 0;
+
+    private void recordTimeStamp(File file) {
+        long ts = SystemClock.elapsedRealtimeNanos();
+        long diff = 0;
+
+        if (0 == gattLastTS) {
+            gattLastTS = ts;
+
+            bgThread = new Thread(new SaveToFileRunnable(file, "inter-packet_time\n".getBytes(), false));
+            bgThread.start();
+
+        } else {
+            diff = ts - gattLastTS;
+            gattLastTS = ts;
+
+            gattBatch[gattBatchIndex] = String.valueOf(diff);
+            gattBatchIndex++;
+
+            if (100 == gattBatchIndex) {
+                String out = String.join("\n", gattBatch);
+                bgThread = new Thread(new SaveToFileRunnable(file, out.getBytes(), true));
+                bgThread.start();
+                gattBatchIndex = 0;
+            }
+        }
+
+    }
+
+
     public void doNotify (WriteData writeData) {
+
+        recordTimeStamp(mGattOutFile);
+
         BluetoothGattCharacteristic characteristic = mGattServer
                 .getService(UART_UUID)
                 .getCharacteristic(RX_UUID);
@@ -281,6 +351,15 @@ class BluetoothLeUartServer extends BluetoothGattServerCallback implements UartB
 
         service.addCharacteristic(txChar);
         service.addCharacteristic(rxChar);
+
+        byte [] b = new byte[512];
+        new Random().nextBytes(b);
+
+        if (this.gattComm == ArgumentSplash.GATT_READ) {
+            rxChar.setValue(b);
+        } else if (this.gattComm == ArgumentSplash.GATT_NOTIFY) {
+            //send after descriptor is written
+        }
 
         return service;
     }
@@ -399,34 +478,15 @@ class BluetoothLeUartServer extends BluetoothGattServerCallback implements UartB
                 responseNeeded, offset, value);
         boolean found = false;
         //Log.i("Peripheral", "onCharacteristicWriteRequest " + characteristic.getUuid().toString());
-        Log.i("Peripheral", new String(value));
-        String data = new String(value);
-        if (data.matches("<.*>")) { //we have a neighbor address update
-            data = data.replaceFirst("<", "");
-            data = data.replaceFirst(">", "");
+        //Log.i("Peripheral", new String(value));
 
-            String [] addresses = data.split("\\s");
-            BluetoothDevice temp = device;
+        recordTimeStamp(mGattOutFile);
 
-            for (int i = 0; i < addresses.length && !found; i++) {
-                //see if we are already connected to that device and ignore if found
-                for (BluetoothDevice dev : mRegisteredDevices) {
-                    if (Objects.equals(addresses[i], dev.getAddress()) && !found) {
-                        found = true;
-                    }
-                }
-            }
-            //we were sent an address of someone we don't know! Go tell someone!
-            if (!found) {
-                Log.i("Peripheral", "Found someone new!");
-                notifyOnDeviceFound(device); //pass a random device since it'll be ignored anyway
-            }
-        } else {
-            //handle long writes?
-            //handle different receive queues
-            characteristic.setValue(value);
-            notifyOnReceive(this, characteristic);
-        }
+        //handle long writes?
+        //handle different receive queues
+        characteristic.setValue(value);
+        //notifyOnReceive(this, characteristic);
+
 
         if (responseNeeded) {
             mGattServer.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null);
@@ -441,8 +501,27 @@ class BluetoothLeUartServer extends BluetoothGattServerCallback implements UartB
                                             int requestId, int offset,
                                             BluetoothGattCharacteristic characteristic) {
 
-//        ReadRequest readReq = new ReadRequest(device, requestId, offset, characteristic);
-//        bleHandler.obtainMessage(MSG_READ, readReq).sendToTarget();
+        recordTimeStamp(mGattOutFile);
+
+        int length = characteristic.getValue().length;
+        if (offset > length) {
+            Log.i("BlueNet", "sending read response end");
+            mGattServer.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, new byte[]{0});
+            return;
+        }
+
+        int size = length - offset;
+        byte[] response = new byte[size];
+
+        for (int i = offset; i < length; i++) {
+            response[i - offset] = characteristic.getValue()[i];
+        }
+
+        if (RX_UUID.equals(characteristic.getUuid())) {
+            //Log.i("BlueNet", String.format("sending read response of length %d of payload of length %d", size, mCurrentMsg.length));
+            mGattServer.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, response);
+            return;
+        }
     }
 
     //clients will try to write to the descriptor to enable notifications.
@@ -463,6 +542,10 @@ class BluetoothLeUartServer extends BluetoothGattServerCallback implements UartB
             if (responseNeeded) {
                 mGattServer.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null);
             }
+
+            byte [] b = new byte[512];
+            new Random().nextBytes(b);
+            send(b);
         } else {
             Log.w(INFO_TAG, "Unknown descriptor write request");
             if (responseNeeded) {
@@ -477,13 +560,19 @@ class BluetoothLeUartServer extends BluetoothGattServerCallback implements UartB
         super.onNotificationSent(device, status);
         if (status == BluetoothGatt.GATT_SUCCESS) {
 
-            WriteData writeData = writeQueue.poll();
+            //FOR TESTING
+            byte [] b = new byte[512];
+            new Random().nextBytes(b);
+            send(b);
 
-            if (null == writeData) { //empty!
-                idle = true;
-            } else {
-                doNotify(writeData);
-            }
+            //REALISTIC
+//            WriteData writeData = writeQueue.poll();
+//
+//            if (null == writeData) { //empty!
+//                idle = true;
+//            } else {
+//                doNotify(writeData);
+//            }
 
             //bleHandler.obtainMessage(MSG_NOTIFIED, device).sendToTarget();
             Log.d("BlueNet", "Notification sent");

--- a/app/src/main/java/com/adafruit/bleuart/BluetoothLeUartServer.java
+++ b/app/src/main/java/com/adafruit/bleuart/BluetoothLeUartServer.java
@@ -45,6 +45,7 @@ import android.os.Message;
 import android.support.annotation.MainThread;
 
 import android.os.SystemClock;
+import android.text.TextUtils;
 
 import android.os.Build;
 import android.util.Log;
@@ -269,7 +270,7 @@ class BluetoothLeUartServer extends BluetoothGattServerCallback implements UartB
             gattBatchIndex++;
 
             if (100 == gattBatchIndex) {
-                String out = String.join("\n", gattBatch);
+                String out = TextUtils.join("\n", gattBatch);
                 bgThread = new Thread(new SaveToFileRunnable(file, out.getBytes(), true));
                 bgThread.start();
                 gattBatchIndex = 0;

--- a/app/src/main/java/com/adafruit/bleuart/BluetoothRestarter.java
+++ b/app/src/main/java/com/adafruit/bleuart/BluetoothRestarter.java
@@ -1,0 +1,65 @@
+package com.adafruit.bleuart;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.BroadcastReceiver;
+import android.content.IntentFilter;
+import android.bluetooth.BluetoothAdapter;
+import android.util.Log;
+
+//https://stackoverflow.com/questions/52832640/programmatically-restarting-bluetooth
+public class BluetoothRestarter {
+
+    private Context mContext;
+    private RestartListener mListener;
+    private BroadcastReceiver mReceiver;
+
+    public BluetoothRestarter(Context context) {
+        mContext = context;
+    }
+
+    public void restart(RestartListener listener) {
+        mListener = listener;
+        if (mReceiver == null) {
+            mReceiver = new BroadcastReceiver() {
+                @Override
+                public void onReceive(Context context, Intent intent) {
+                    String action = intent.getAction();
+
+                    //https://stackoverflow.com/questions/9693755/detecting-state-changes-made-to-the-bluetoothadapter
+                    if (action.equals(BluetoothAdapter.ACTION_STATE_CHANGED)) {
+                        final int state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE,
+                                BluetoothAdapter.ERROR);
+                        Log.e("BluetoothRestarter", "HERE");
+                        switch (state) {
+                            case BluetoothAdapter.STATE_TURNING_OFF:
+                                Log.i ("BluetoothRestarter", "Turning Bluetooth off");
+                                break;
+                            case BluetoothAdapter.STATE_OFF:
+                                if (!BluetoothAdapter.getDefaultAdapter().enable()) {
+                                    Log.e("BluetoothRestarter", "Failed to start bluetooth!");
+                                } else {
+                                    Log.e("BluetoothRestarter", "Starting bluetooth!");
+                                }
+                                break;
+                            case BluetoothAdapter.STATE_TURNING_ON:
+                                Log.i ("BluetoothRestarter", "Turning Bluetooth on");
+                                break;
+                            case BluetoothAdapter.STATE_ON:
+                                context.unregisterReceiver(this);
+                                mListener.onRestartComplete();
+                                break;
+                        }
+                    }
+
+                }
+            };
+            mContext.registerReceiver(mReceiver, new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED));
+            BluetoothAdapter.getDefaultAdapter().disable();
+        }
+    }
+
+    public interface RestartListener {
+        void onRestartComplete();
+    }
+}

--- a/app/src/main/java/com/adafruit/bleuart/MainActivity.java
+++ b/app/src/main/java/com/adafruit/bleuart/MainActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.os.Bundle;
+import android.os.PowerManager;
 import android.text.method.ScrollingMovementMethod;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -21,6 +22,9 @@ public class MainActivity extends Activity implements UartBase.HostCallback {
     private EditText input;
     private Button   send;
     private CheckBox newline;
+
+    PowerManager powerManager;
+    PowerManager.WakeLock wakeLock;
 
     // Bluetooth LE UART instance.  This is defined in BluetoothLeUart.java.
     private DualRoleBluetoothLeUart uart;
@@ -81,6 +85,11 @@ public class MainActivity extends Activity implements UartBase.HostCallback {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        powerManager = (PowerManager) getSystemService(POWER_SERVICE);
+        wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,
+                "AndroidBLEUART::MyWakelockTag");
+        wakeLock.acquire();
+
         // Grab references to UI elements.
         messages = (TextView) findViewById(R.id.messages);
         input = (EditText) findViewById(R.id.input);
@@ -136,6 +145,7 @@ public class MainActivity extends Activity implements UartBase.HostCallback {
         uart.stop();
         //uart.unregisterCallback(this);
         uart.disconnect();
+        wakeLock.release();
     }
 
     @Override

--- a/app/src/main/java/com/adafruit/bleuart/MainActivity.java
+++ b/app/src/main/java/com/adafruit/bleuart/MainActivity.java
@@ -117,20 +117,33 @@ public class MainActivity extends Activity implements UartBase.HostCallback {
         return true;
     }
 
+    boolean mStarted = false;
     // OnResume, called right before UI is displayed.  Connect to the bluetooth device.
     @Override
     protected void onResume() {
         super.onResume();
         uart.registerCallback(this);
-        uart.start();
+        if (!mStarted) {
+            uart.start();
+        }
     }
 
     // OnStop, called right before the activity loses foreground focus.  Close the BTLE connection.
     @Override
     protected void onStop() {
         super.onStop();
-        uart.unregisterCallback(this);
+
+        uart.stop();
+        //uart.unregisterCallback(this);
         uart.disconnect();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+
+//        uart.stop();
+//        uart.disconnect();
     }
 
     @Override


### PR DESCRIPTION
This is to add the communication differentiation for experiments. The different communication methods are Write Command, Write Request, Read, and Notify. The associated timing is between two consecutive operations and is written to a file called gatt_cap.txt. Also included here is an edit to the scan logging such that each advertisement receipt time is recorded rather than averaging.